### PR TITLE
Update README.md to reflect Windows-only platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Status](https://img.shields.io/badge/status-active-success.svg)
-![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20MacOS-lightgrey.svg)
+![Platform](https://img.shields.io/badge/platform-Windows-lightgrey.svg)
 [![Buy Me a Coffee](https://img.shields.io/badge/☕-Buy%20me%20a%20coffee-orange.svg)](https://www.buymeacoffee.com/badyast)
 
 Ein inoffizieller Editor für Spielstände von **Gates of Hell: Ostfront**.  
@@ -24,7 +24,7 @@ Die Nutzung geschieht auf eigene Verantwortung.
 ## 🛠️ Installation
 1. Lade dir die neueste Version unter [Releases](../../releases) herunter.  
 2. Entpacke die Dateien in einen beliebigen Ordner.  
-3. Starte `GOHSaveEditor.exe` (Windows) oder die jeweilige Build-Version für dein System.  
+3. Starte `GOHSaveEditor.exe`.  
 
 ---
 


### PR DESCRIPTION
This PR addresses issue #5 by updating the README.md to correctly reflect that only Windows is actively supported, not multiple platforms.

**Changes:**
- Updated platform badge to show only Windows instead of multiple platforms
- Simplified installation instructions to remove references to other system builds

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)