### PR TITLE
fix: Replace 'Ungroupiert' with 'ungruppiert' in text outputs

### DIFF
--- a/MainForm.pas
+++ b/MainForm.pas
@@ -2079,7 +2079,7 @@ end;
 function TFrmMain.GetStageGroupDisplay(const Stage: string): string;
 begin
   if Stage = '' then
-    Result := ' [Ungroupiert]'
+    Result := ' [ungruppiert]'
   else
     Result := ' [' + Stage + ']';
 end;


### PR DESCRIPTION
Fixes #7

This PR corrects the capitalization of German text in the application by replacing "Ungroupiert" with "ungruppiert" in text outputs.

## Changes
- Updated `GetStageGroupDisplay` function in MainForm.pas
- Changed display text from "[Ungroupiert]" to "[ungruppiert]"

Generated with [Claude Code](https://claude.ai/code)